### PR TITLE
fix(inotify_tracker): enhance error handling in run method

### DIFF
--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -217,7 +217,7 @@ func (shared *InotifyTracker) sendEvent(event fsnotify.Event) {
 func (shared *InotifyTracker) run() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		util.Fatal("failed to create Watcher")
+		util.Fatal("failed to create Watcher: %v", err)
 	}
 	shared.watcher = watcher
 


### PR DESCRIPTION
This pull request includes a minor but important change to the error handling in the `InotifyTracker` class. The change improves the logging of errors when creating a new `Watcher` by including the error message in the log output.

* [`watch/inotify_tracker.go`](diffhunk://#diff-8dae8076fa4496081a61af2da16eec1866dacdd407c2f934fe3045cf9faaaeb7L220-R220): Enhanced the error message in `util.Fatal` to include the actual error (`err`) when failing to create a `Watcher`.